### PR TITLE
Fix: remove bad button notice

### DIFF
--- a/anarchy_bot/common.py
+++ b/anarchy_bot/common.py
@@ -411,9 +411,7 @@ def mention_nolink(
 async def bad_button(
     cb: CallbackQuery,
 ) -> None:
-    await cb.answer(
-        text = t('bad_button_cb', cb),
-    )
+    await cb.answer()
 
 
 async def cb_bugreport(

--- a/anarchy_bot/lang/en.yml
+++ b/anarchy_bot/lang/en.yml
@@ -87,8 +87,6 @@ ask_to_set_logs_chat_msg:
   do you want to set chat "{title}" as chat for logs?
 confirm_set_logs_chat_button:
   ✏️ set chat
-bad_button_cb:
-  ❌ bad button
 more_info_button:
   📋 more info
 choose_page_msg:


### PR DESCRIPTION
## Summary
- remove `bad_button_cb` from translations
- change `bad_button` helper to silently answer

## Testing
- `pyright` *(fails: missing dependencies)*
- `pytest -q`
- `python -m py_compile anarchy_bot/common.py`


------
https://chatgpt.com/codex/tasks/task_e_683caca74d388326b4ffb6e4f589fa94